### PR TITLE
Fix lfmt linkage error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SOURCE = simulate.cc
 all: sim sim-v
 
 sim: $(SOURCE)
-	clang++ -std=c++20 -O2 -lfmt $< -o $@
+	clang++ -std=c++20 -O2 $< -lfmt -o $@
 
 sim-v: $(SOURCE)
-	clang++ -std=c++20 -O2 -lfmt -DVERB=1 $< -o $@
+	clang++ -std=c++20 -O2 -DVERB=1 $< -lfmt -o $@


### PR DESCRIPTION
Correct Makefile and call -lfmt after source to prevent linking errors